### PR TITLE
Fix bug in square() function

### DIFF
--- a/script.R
+++ b/script.R
@@ -1,5 +1,5 @@
 square <- function(x) {
-  return(x + x)
+  x * x
 }
 
 cube <- function(x) {


### PR DESCRIPTION
The square() function had a bug where it returned (x + x) instead of (x * x). It has been fixed