### PR TITLE
Fix bug in square function

### DIFF
--- a/script.R
+++ b/script.R
@@ -1,5 +1,5 @@
 square <- function(x) {
-  return(x + x)
+  return(x * x) 
 }
 
 cube <- function(x) {

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result5 <- x * x * x
-  return(result5)
+  result6 <- x * x * x
+  return(result6)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result17 <- x * x * x
-  return(result17)
+  result18 <- x * x * x
+  return(result18)
 }

--- a/script.R
+++ b/script.R
@@ -1,8 +1,8 @@
 square <- function(x) {
-  return(x * x)
+  return(x + x)
 }
 
 cube <- function(x) {
-  result23 <- x * x * x
-  return(result23)
+  result11 <- x * x * x
+  return(result11)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result21 <- x * x * x
-  return(result21)
+  result22 <- x * x * x
+  return(result22)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result7 <- x * x * x
-  return(result7)
+  result8 <- x * x * x
+  return(result8)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result16 <- x * x * x
-  return(result16)
+  result17 <- x * x * x
+  return(result17)
 }

--- a/script.R
+++ b/script.R
@@ -1,0 +1,8 @@
+square <- function(x) {
+  return(x * x)
+}
+
+cube <- function(x) {
+  result <- x * x * x
+  return(result)
+}

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result15 <- x * x * x
-  return(result15)
+  result16 <- x * x * x
+  return(result16)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result8 <- x * x * x
-  return(result8)
+  result9 <- x * x * x
+  return(result9)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result2 <- x * x * x
-  return(result2)
+  result3 <- x * x * x
+  return(result3)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result12 <- x * x * x
-  return(result12)
+  result13 <- x * x * x
+  return(result13)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result18 <- x * x * x
-  return(result18)
+  result19 <- x * x * x
+  return(result19)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result6 <- x * x * x
-  return(result6)
+  result7 <- x * x * x
+  return(result7)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result13 <- x * x * x
-  return(result13)
+  result14 <- x * x * x
+  return(result14)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result19 <- x * x * x
-  return(result19)
+  result20 <- x * x * x
+  return(result20)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result <- x * x * x
-  return(result)
+  result1 <- x * x * x
+  return(result1)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result14 <- x * x * x
-  return(result14)
+  result15 <- x * x * x
+  return(result15)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result10 <- x * x * x
-  return(result10)
+  result11 <- x * x * x
+  return(result11)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result4 <- x * x * x
-  return(result4)
+  result5 <- x * x * x
+  return(result5)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result22 <- x * x * x
-  return(result22)
+  result23 <- x * x * x
+  return(result23)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result11 <- x * x * x
-  return(result11)
+  result12 <- x * x * x
+  return(result12)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result9 <- x * x * x
-  return(result9)
+  result10 <- x * x * x
+  return(result10)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result3 <- x * x * x
-  return(result3)
+  result4 <- x * x * x
+  return(result4)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result20 <- x * x * x
-  return(result20)
+  result21 <- x * x * x
+  return(result21)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result1 <- x * x * x
-  return(result1)
+  result2 <- x * x * x
+  return(result2)
 }


### PR DESCRIPTION
Bug:
The square() function in script.R was incorrectly implemented as x + x, which returns double the value instead of the square.

How I found it:
I used git bisect to identify the exact commit where the bug was introduced. By marking the known good and bad commits and testing intermediate ones.

Fix:
I corrected the implementation of square().
This now returns the mathematically correct square of the input.