### PR TITLE
Fix bug in square function

### DIFF
--- a/script.R
+++ b/script.R
@@ -1,6 +1,5 @@
 square <- function(x) {
-  res82 <- x + x
-  return(res82) 
+  return(x * x)  # Fix the bug (it was previously x + x)
 }
 
 cube <- function(x) {

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res36 <- x + x
-  return(res36) 
+  res37 <- x + x
+  return(res37) 
 }
 
 cube <- function(x) {
-  res36 <- x * x * x
-  return(res36)
+  res37 <- x * x * x
+  return(res37)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res79 <- x + x
-  return(res79) 
+  res80 <- x + x
+  return(res80) 
 }
 
 cube <- function(x) {
-  res79 <- x * x * x
-  return(res79)
+  res80 <- x * x * x
+  return(res80)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res45 <- x + x
-  return(res45) 
+  res46 <- x + x
+  return(res46) 
 }
 
 cube <- function(x) {
-  res45 <- x * x * x
-  return(res45)
+  res46 <- x * x * x
+  return(res46)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res50 <- x + x
-  return(res50) 
+  res51 <- x + x
+  return(res51) 
 }
 
 cube <- function(x) {
-  res50 <- x * x * x
-  return(res50)
+  res51 <- x * x * x
+  return(res51)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res58 <- x + x
-  return(res58) 
+  res59 <- x + x
+  return(res59) 
 }
 
 cube <- function(x) {
-  res58 <- x * x * x
-  return(res58)
+  res59 <- x * x * x
+  return(res59)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res57 <- x + x
-  return(res57) 
+  res58 <- x + x
+  return(res58) 
 }
 
 cube <- function(x) {
-  res57 <- x * x * x
-  return(res57)
+  res58 <- x * x * x
+  return(res58)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result5 <- x * x * x
-  return(result5)
+  result6 <- x * x * x
+  return(result6)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res41 <- x + x
-  return(res41) 
+  res42 <- x + x
+  return(res42) 
 }
 
 cube <- function(x) {
-  res41 <- x * x * x
-  return(res41)
+  res42 <- x * x * x
+  return(res42)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result17 <- x * x * x
-  return(result17)
+  result18 <- x * x * x
+  return(result18)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res26 <- x + x
-  return(res26) 
+  res27 <- x + x
+  return(res27) 
 }
 
 cube <- function(x) {
-  res26 <- x * x * x
-  return(res26)
+  res27 <- x * x * x
+  return(res27)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res46 <- x + x
-  return(res46) 
+  res47 <- x + x
+  return(res47) 
 }
 
 cube <- function(x) {
-  res46 <- x * x * x
-  return(res46)
+  res47 <- x * x * x
+  return(res47)
 }

--- a/script.R
+++ b/script.R
@@ -1,8 +1,8 @@
 square <- function(x) {
-  return(x * x)
+  return(x + x)
 }
 
 cube <- function(x) {
-  result23 <- x * x * x
-  return(result23)
+  result11 <- x * x * x
+  return(result11)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res65 <- x + x
-  return(res65) 
+  res66 <- x + x
+  return(res66) 
 }
 
 cube <- function(x) {
-  res65 <- x * x * x
-  return(res65)
+  res66 <- x * x * x
+  return(res66)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res66 <- x + x
-  return(res66) 
+  res67 <- x + x
+  return(res67) 
 }
 
 cube <- function(x) {
-  res66 <- x * x * x
-  return(res66)
+  res67 <- x * x * x
+  return(res67)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result21 <- x * x * x
-  return(result21)
+  result22 <- x * x * x
+  return(result22)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res38 <- x + x
-  return(res38) 
+  res39 <- x + x
+  return(res39) 
 }
 
 cube <- function(x) {
-  res38 <- x * x * x
-  return(res38)
+  res39 <- x * x * x
+  return(res39)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res62 <- x + x
-  return(res62) 
+  res63 <- x + x
+  return(res63) 
 }
 
 cube <- function(x) {
-  res62 <- x * x * x
-  return(res62)
+  res63 <- x * x * x
+  return(res63)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result7 <- x * x * x
-  return(result7)
+  result8 <- x * x * x
+  return(result8)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result16 <- x * x * x
-  return(result16)
+  result17 <- x * x * x
+  return(result17)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res52 <- x + x
-  return(res52) 
+  res53 <- x + x
+  return(res53) 
 }
 
 cube <- function(x) {
-  res52 <- x * x * x
-  return(res52)
+  res53 <- x * x * x
+  return(res53)
 }

--- a/script.R
+++ b/script.R
@@ -1,0 +1,8 @@
+square <- function(x) {
+  return(x * x)
+}
+
+cube <- function(x) {
+  result <- x * x * x
+  return(result)
+}

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result15 <- x * x * x
-  return(result15)
+  result16 <- x * x * x
+  return(result16)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res77 <- x + x
-  return(res77) 
+  res78 <- x + x
+  return(res78) 
 }
 
 cube <- function(x) {
-  res77 <- x * x * x
-  return(res77)
+  res78 <- x * x * x
+  return(res78)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result8 <- x * x * x
-  return(result8)
+  result9 <- x * x * x
+  return(result9)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res44 <- x + x
-  return(res44) 
+  res45 <- x + x
+  return(res45) 
 }
 
 cube <- function(x) {
-  res44 <- x * x * x
-  return(res44)
+  res45 <- x * x * x
+  return(res45)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result2 <- x * x * x
-  return(result2)
+  result3 <- x * x * x
+  return(result3)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res68 <- x + x
-  return(res68) 
+  res69 <- x + x
+  return(res69) 
 }
 
 cube <- function(x) {
-  res68 <- x * x * x
-  return(res68)
+  res69 <- x * x * x
+  return(res69)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res19 <- x + x
-  return(res19) 
+  res20 <- x + x
+  return(res20) 
 }
 
 cube <- function(x) {
-  res19 <- x * x * x
-  return(res19)
+  res20 <- x * x * x
+  return(res20)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result12 <- x * x * x
-  return(result12)
+  result13 <- x * x * x
+  return(result13)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res47 <- x + x
-  return(res47) 
+  res48 <- x + x
+  return(res48) 
 }
 
 cube <- function(x) {
-  res47 <- x * x * x
-  return(res47)
+  res48 <- x * x * x
+  return(res48)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res48 <- x + x
-  return(res48) 
+  res49 <- x + x
+  return(res49) 
 }
 
 cube <- function(x) {
-  res48 <- x * x * x
-  return(res48)
+  res49 <- x * x * x
+  return(res49)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res81 <- x + x
-  return(res81) 
+  res82 <- x + x
+  return(res82) 
 }
 
 cube <- function(x) {
-  res81 <- x * x * x
-  return(res81)
+  res82 <- x * x * x
+  return(res82)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result18 <- x * x * x
-  return(result18)
+  result19 <- x * x * x
+  return(result19)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res42 <- x + x
-  return(res42) 
+  res43 <- x + x
+  return(res43) 
 }
 
 cube <- function(x) {
-  res42 <- x * x * x
-  return(res42)
+  res43 <- x * x * x
+  return(res43)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res31 <- x + x
-  return(res31) 
+  res32 <- x + x
+  return(res32) 
 }
 
 cube <- function(x) {
-  res31 <- x * x * x
-  return(res31)
+  res32 <- x * x * x
+  return(res32)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res72 <- x + x
-  return(res72) 
+  res73 <- x + x
+  return(res73) 
 }
 
 cube <- function(x) {
-  res72 <- x * x * x
-  return(res72)
+  res73 <- x * x * x
+  return(res73)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res55 <- x + x
-  return(res55) 
+  res56 <- x + x
+  return(res56) 
 }
 
 cube <- function(x) {
-  res55 <- x * x * x
-  return(res55)
+  res56 <- x * x * x
+  return(res56)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res53 <- x + x
-  return(res53) 
+  res54 <- x + x
+  return(res54) 
 }
 
 cube <- function(x) {
-  res53 <- x * x * x
-  return(res53)
+  res54 <- x * x * x
+  return(res54)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res16 <- x + x
-  return(res16) 
+  res17 <- x + x
+  return(res17) 
 }
 
 cube <- function(x) {
-  res16 <- x * x * x
-  return(res16)
+  res17 <- x * x * x
+  return(res17)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res74 <- x + x
-  return(res74) 
+  res75 <- x + x
+  return(res75) 
 }
 
 cube <- function(x) {
-  res74 <- x * x * x
-  return(res74)
+  res75 <- x * x * x
+  return(res75)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result6 <- x * x * x
-  return(result6)
+  result7 <- x * x * x
+  return(result7)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res69 <- x + x
-  return(res69) 
+  res70 <- x + x
+  return(res70) 
 }
 
 cube <- function(x) {
-  res69 <- x * x * x
-  return(res69)
+  res70 <- x * x * x
+  return(res70)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res14 <- x + x
-  return(res14) 
+  res15 <- x + x
+  return(res15) 
 }
 
 cube <- function(x) {
-  res14 <- x * x * x
-  return(res14)
+  res15 <- x * x * x
+  return(res15)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res63 <- x + x
-  return(res63) 
+  res64 <- x + x
+  return(res64) 
 }
 
 cube <- function(x) {
-  res63 <- x * x * x
-  return(res63)
+  res64 <- x * x * x
+  return(res64)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result13 <- x * x * x
-  return(result13)
+  result14 <- x * x * x
+  return(result14)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res49 <- x + x
-  return(res49) 
+  res50 <- x + x
+  return(res50) 
 }
 
 cube <- function(x) {
-  res49 <- x * x * x
-  return(res49)
+  res50 <- x * x * x
+  return(res50)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res37 <- x + x
-  return(res37) 
+  res38 <- x + x
+  return(res38) 
 }
 
 cube <- function(x) {
-  res37 <- x * x * x
-  return(res37)
+  res38 <- x * x * x
+  return(res38)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res54 <- x + x
-  return(res54) 
+  res55 <- x + x
+  return(res55) 
 }
 
 cube <- function(x) {
-  res54 <- x * x * x
-  return(res54)
+  res55 <- x * x * x
+  return(res55)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result19 <- x * x * x
-  return(result19)
+  result20 <- x * x * x
+  return(result20)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res25 <- x + x
-  return(res25) 
+  res26 <- x + x
+  return(res26) 
 }
 
 cube <- function(x) {
-  res25 <- x * x * x
-  return(res25)
+  res26 <- x * x * x
+  return(res26)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res70 <- x + x
-  return(res70) 
+  res71 <- x + x
+  return(res71) 
 }
 
 cube <- function(x) {
-  res70 <- x * x * x
-  return(res70)
+  res71 <- x * x * x
+  return(res71)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res23 <- x + x
-  return(res23) 
+  res24 <- x + x
+  return(res24) 
 }
 
 cube <- function(x) {
-  res23 <- x * x * x
-  return(res23)
+  res24 <- x * x * x
+  return(res24)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res59 <- x + x
-  return(res59) 
+  res60 <- x + x
+  return(res60) 
 }
 
 cube <- function(x) {
-  res59 <- x * x * x
-  return(res59)
+  res60 <- x * x * x
+  return(res60)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result <- x * x * x
-  return(result)
+  result1 <- x * x * x
+  return(result1)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result14 <- x * x * x
-  return(result14)
+  result15 <- x * x * x
+  return(result15)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res71 <- x + x
-  return(res71) 
+  res72 <- x + x
+  return(res72) 
 }
 
 cube <- function(x) {
-  res71 <- x * x * x
-  return(res71)
+  res72 <- x * x * x
+  return(res72)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res61 <- x + x
-  return(res61) 
+  res62 <- x + x
+  return(res62) 
 }
 
 cube <- function(x) {
-  res61 <- x * x * x
-  return(res61)
+  res62 <- x * x * x
+  return(res62)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res56 <- x + x
-  return(res56) 
+  res57 <- x + x
+  return(res57) 
 }
 
 cube <- function(x) {
-  res56 <- x * x * x
-  return(res56)
+  res57 <- x * x * x
+  return(res57)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res80 <- x + x
-  return(res80) 
+  res81 <- x + x
+  return(res81) 
 }
 
 cube <- function(x) {
-  res80 <- x * x * x
-  return(res80)
+  res81 <- x * x * x
+  return(res81)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result10 <- x * x * x
-  return(result10)
+  result11 <- x * x * x
+  return(result11)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res15 <- x + x
-  return(res15) 
+  res16 <- x + x
+  return(res16) 
 }
 
 cube <- function(x) {
-  res15 <- x * x * x
-  return(res15)
+  res16 <- x * x * x
+  return(res16)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res29 <- x + x
-  return(res29) 
+  res30 <- x + x
+  return(res30) 
 }
 
 cube <- function(x) {
-  res29 <- x * x * x
-  return(res29)
+  res30 <- x * x * x
+  return(res30)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res33 <- x + x
-  return(res33) 
+  res34 <- x + x
+  return(res34) 
 }
 
 cube <- function(x) {
-  res33 <- x * x * x
-  return(res33)
+  res34 <- x * x * x
+  return(res34)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res21 <- x + x
-  return(res21) 
+  res22 <- x + x
+  return(res22) 
 }
 
 cube <- function(x) {
-  res21 <- x * x * x
-  return(res21)
+  res22 <- x * x * x
+  return(res22)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res67 <- x + x
-  return(res67) 
+  res68 <- x + x
+  return(res68) 
 }
 
 cube <- function(x) {
-  res67 <- x * x * x
-  return(res67)
+  res68 <- x * x * x
+  return(res68)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res12 <- x + x
-  return(res12) 
+  res13 <- x + x
+  return(res13) 
 }
 
 cube <- function(x) {
-  res12 <- x * x * x
-  return(res12)
+  res13 <- x * x * x
+  return(res13)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result4 <- x * x * x
-  return(result4)
+  result5 <- x * x * x
+  return(result5)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res24 <- x + x
-  return(res24) 
+  res25 <- x + x
+  return(res25) 
 }
 
 cube <- function(x) {
-  res24 <- x * x * x
-  return(res24)
+  res25 <- x * x * x
+  return(res25)
 }

--- a/script.R
+++ b/script.R
@@ -1,8 +1,9 @@
 square <- function(x) {
-  return(x + x)
+  res12 <- x + x
+  return(res12) 
 }
 
 cube <- function(x) {
-  result11 <- x * x * x
-  return(result11)
+  res12 <- x * x * x
+  return(res12)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res32 <- x + x
-  return(res32) 
+  res33 <- x + x
+  return(res33) 
 }
 
 cube <- function(x) {
-  res32 <- x * x * x
-  return(res32)
+  res33 <- x * x * x
+  return(res33)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result22 <- x * x * x
-  return(result22)
+  result23 <- x * x * x
+  return(result23)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res13 <- x + x
-  return(res13) 
+  res14 <- x + x
+  return(res14) 
 }
 
 cube <- function(x) {
-  res13 <- x * x * x
-  return(res13)
+  res14 <- x * x * x
+  return(res14)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res43 <- x + x
-  return(res43) 
+  res44 <- x + x
+  return(res44) 
 }
 
 cube <- function(x) {
-  res43 <- x * x * x
-  return(res43)
+  res44 <- x * x * x
+  return(res44)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res51 <- x + x
-  return(res51) 
+  res52 <- x + x
+  return(res52) 
 }
 
 cube <- function(x) {
-  res51 <- x * x * x
-  return(res51)
+  res52 <- x * x * x
+  return(res52)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res34 <- x + x
-  return(res34) 
+  res35 <- x + x
+  return(res35) 
 }
 
 cube <- function(x) {
-  res34 <- x * x * x
-  return(res34)
+  res35 <- x * x * x
+  return(res35)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res27 <- x + x
-  return(res27) 
+  res28 <- x + x
+  return(res28) 
 }
 
 cube <- function(x) {
-  res27 <- x * x * x
-  return(res27)
+  res28 <- x * x * x
+  return(res28)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result11 <- x * x * x
-  return(result11)
+  result12 <- x * x * x
+  return(result12)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res76 <- x + x
-  return(res76) 
+  res77 <- x + x
+  return(res77) 
 }
 
 cube <- function(x) {
-  res76 <- x * x * x
-  return(res76)
+  res77 <- x * x * x
+  return(res77)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res75 <- x + x
-  return(res75) 
+  res76 <- x + x
+  return(res76) 
 }
 
 cube <- function(x) {
-  res75 <- x * x * x
-  return(res75)
+  res76 <- x * x * x
+  return(res76)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res40 <- x + x
-  return(res40) 
+  res41 <- x + x
+  return(res41) 
 }
 
 cube <- function(x) {
-  res40 <- x * x * x
-  return(res40)
+  res41 <- x * x * x
+  return(res41)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res28 <- x + x
-  return(res28) 
+  res29 <- x + x
+  return(res29) 
 }
 
 cube <- function(x) {
-  res28 <- x * x * x
-  return(res28)
+  res29 <- x * x * x
+  return(res29)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res17 <- x + x
-  return(res17) 
+  res18 <- x + x
+  return(res18) 
 }
 
 cube <- function(x) {
-  res17 <- x * x * x
-  return(res17)
+  res18 <- x * x * x
+  return(res18)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result9 <- x * x * x
-  return(result9)
+  result10 <- x * x * x
+  return(result10)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result3 <- x * x * x
-  return(result3)
+  result4 <- x * x * x
+  return(result4)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res64 <- x + x
-  return(res64) 
+  res65 <- x + x
+  return(res65) 
 }
 
 cube <- function(x) {
-  res64 <- x * x * x
-  return(res64)
+  res65 <- x * x * x
+  return(res65)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res22 <- x + x
-  return(res22) 
+  res23 <- x + x
+  return(res23) 
 }
 
 cube <- function(x) {
-  res22 <- x * x * x
-  return(res22)
+  res23 <- x * x * x
+  return(res23)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result20 <- x * x * x
-  return(result20)
+  result21 <- x * x * x
+  return(result21)
 }

--- a/script.R
+++ b/script.R
@@ -3,6 +3,6 @@ square <- function(x) {
 }
 
 cube <- function(x) {
-  result1 <- x * x * x
-  return(result1)
+  result2 <- x * x * x
+  return(result2)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res60 <- x + x
-  return(res60) 
+  res61 <- x + x
+  return(res61) 
 }
 
 cube <- function(x) {
-  res60 <- x * x * x
-  return(res60)
+  res61 <- x * x * x
+  return(res61)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res30 <- x + x
-  return(res30) 
+  res31 <- x + x
+  return(res31) 
 }
 
 cube <- function(x) {
-  res30 <- x * x * x
-  return(res30)
+  res31 <- x * x * x
+  return(res31)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res35 <- x + x
-  return(res35) 
+  res36 <- x + x
+  return(res36) 
 }
 
 cube <- function(x) {
-  res35 <- x * x * x
-  return(res35)
+  res36 <- x * x * x
+  return(res36)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res39 <- x + x
-  return(res39) 
+  res40 <- x + x
+  return(res40) 
 }
 
 cube <- function(x) {
-  res39 <- x * x * x
-  return(res39)
+  res40 <- x * x * x
+  return(res40)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res73 <- x + x
-  return(res73) 
+  res74 <- x + x
+  return(res74) 
 }
 
 cube <- function(x) {
-  res73 <- x * x * x
-  return(res73)
+  res74 <- x * x * x
+  return(res74)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res18 <- x + x
-  return(res18) 
+  res19 <- x + x
+  return(res19) 
 }
 
 cube <- function(x) {
-  res18 <- x * x * x
-  return(res18)
+  res19 <- x * x * x
+  return(res19)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res20 <- x + x
-  return(res20) 
+  res21 <- x + x
+  return(res21) 
 }
 
 cube <- function(x) {
-  res20 <- x * x * x
-  return(res20)
+  res21 <- x * x * x
+  return(res21)
 }

--- a/script.R
+++ b/script.R
@@ -1,9 +1,9 @@
 square <- function(x) {
-  res78 <- x + x
-  return(res78) 
+  res79 <- x + x
+  return(res79) 
 }
 
 cube <- function(x) {
-  res78 <- x * x * x
-  return(res78)
+  res79 <- x * x * x
+  return(res79)
 }


### PR DESCRIPTION
### Bug description
The `square()` function in script.R was returning `x + x` instead of `x * x`, causing incorrect square calculations.

### Process to find the bug
I used `git bisect` to automatically locate the commit that introduced the bug.
- Marked the current commit as bad.
- Marked the initial commit (6032372) as good.
- Ran bisect steps until commit b856025 was identified as the first bad commit.

### Fix
- Corrected the `square()` function to return `x * x`.
- Added the fix in branch `fix-square-bug`.

Please review and merge. Thanks!
